### PR TITLE
[Hotfix] WAS & Redis 서버 공통 네트워크로 통합

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ server:
   port: 8080
 spring:
   redis:
-    host: localhost
+    host: drcal-network
     port: 6379
   datasource:
     url: jdbc:mysql://minidb.c74fq5jjb22v.ap-northeast-2.rds.amazonaws.com:3306/minidb?serverTimezone=Asia/Seoul


### PR DESCRIPTION
# [Hotfix] WAS & Redis 서버 공통 네트워크로 통합

* 커스텀 정의 도커 네트워크를 바라보도록 application.yml 수정