### PR TITLE
[Fix] WAS & Redis 연결 이슈로 인한 Redis 미사용 API 임시 추가 및 연결

### DIFF
--- a/src/main/java/com/fc/mini3server/controller/ScheduleController.java
+++ b/src/main/java/com/fc/mini3server/controller/ScheduleController.java
@@ -97,6 +97,13 @@ public class ScheduleController {
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 
+    @PostMapping("/on/redis")
+    public ResponseEntity<ApiUtils.ApiResult<String>> startWorkUsingRedis() {
+        Long userId = userService.getUser().getId();
+        scheduleService.startWorkUsingRedis(userId);
+        return ResponseEntity.ok(ApiUtils.success(null));
+    }
+
     @PostMapping("/off")
     public ResponseEntity<ApiUtils.ApiResult<String>> endWork() {
         Long userId = userService.getUser().getId();

--- a/src/main/java/com/fc/mini3server/controller/ScheduleController.java
+++ b/src/main/java/com/fc/mini3server/controller/ScheduleController.java
@@ -4,14 +4,11 @@ import com.fc.mini3server._core.handler.Message;
 import com.fc.mini3server._core.utils.ApiUtils;
 import com.fc.mini3server.domain.Schedule;
 import com.fc.mini3server.domain.CategoryEnum;
-import com.fc.mini3server.domain.User;
-import com.fc.mini3server.dto.UserResponseDTO;
 import com.fc.mini3server.service.ScheduleService;
 import com.fc.mini3server.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -96,7 +93,7 @@ public class ScheduleController {
     @PostMapping("/on")
     public ResponseEntity<ApiUtils.ApiResult<String>> startWork() {
         Long userId = userService.getUser().getId();
-        scheduleService.startWorkUsingRedis(userId);
+        scheduleService.startWork(userId);
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 


### PR DESCRIPTION
# [Fix] WAS & Redis 연결 이슈로 인한 Redis 미사용 API 임시 추가 및 연결

* 문제 : WAS 컨테이너 & Redis 컨테이너 연결 문제로 인해 출근 API 호출 시 500 에러가 발생함
* 조치 상황 : docker network 구성 후 같은 네트워크로 연결 시도했으나 실패
* 결론 : Redis 미사용 API 임시 연결을 통해 서비스 지속하되, Redis 사용하는 API 추가하여 Reids & WAS 연결 이슈 지속 대응