### PR TITLE
[Fix] Bean 동시 조회를 막기 위한 기존 서비스 메서드 주석 처리 및 import 라인 수정

### DIFF
--- a/src/main/java/com/fc/mini3server/service/UserService.java
+++ b/src/main/java/com/fc/mini3server/service/UserService.java
@@ -12,6 +12,8 @@ import com.fc.mini3server.repository.*;
 import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -48,7 +50,6 @@ public class UserService {
     private final HospitalRepository hospitalRepository;
     private final DeptRepository deptRepository;
     private final WorkRepository workRepository;
-    private final WorkRepositoryCustom workRepositoryCustom;
 
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManager authenticationManager;
@@ -135,17 +136,17 @@ public class UserService {
         return user;
     }
 
-    public Work getWorkInfoWithUser(User user) {
-        LocalDate today = LocalDate.now();
-        Work work = workRepository.findFirstByUserIdAndStartTimeBetween(
-                user.getId(), today.atStartOfDay(), today.atTime(23, 59, 59)
-        );
-        return work;
-    }
+//    public Work getWorkInfoWithUser(User user) {
+//        LocalDate today = LocalDate.now();
+//        Work work = workRepository.findFirstByUserIdAndStartTimeBetween(
+//                user.getId(), today.atStartOfDay(), today.atTime(23, 59, 59)
+//        );
+//        return work;
+//    }
 
     public Work getWorkInfoWithUserWithQueryDSL(User user) {
         LocalDate today = LocalDate.now();
-        Work work = workRepositoryCustom.findFirstWorkByUserIdAndStartTimeBetween(
+        Work work = workRepository.findFirstWorkByUserIdAndStartTimeBetween(
                 user.getId(), today.atStartOfDay(), today.atTime(23, 59, 59)
         );
         return work;


### PR DESCRIPTION
# [Fix] Bean 동시 조회를 막기 위한 기존 서비스 메서드 주석 처리 및 import 라인 수정

UserService에서 마이페이지 조회 시 WorkRepository와 WorkRepositoryCustom 인터페이스를 이중으로 Bean으로 참조하여 컴파일 에러 발생함.

## 해결
* import 라인 WorkRepository 하나로 구성
* 기존 WorkRepository JPA 사용 메서드(UserService 클래스 내) 주석 처리하여 Bean을 하나만 참조하도록 수정함.